### PR TITLE
Removing double negative causing script to fail

### DIFF
--- a/html2canvasproxy.php
+++ b/html2canvasproxy.php
@@ -48,7 +48,7 @@ function remove_old_files(){
 	}
 }
 
-if(!function_exists('error_get_last')===false){
+if(function_exists('error_get_last') === false){
 	//this function does not exist by default in php4.3, error_get_last is only to prevent error message: Function not defined
 	function error_get_last(){ return null; }
 }


### PR DESCRIPTION
This double negative seems to be a typo. It was causing the script to fail for me and removing it seems to work.
