### PR TITLE
fix check to use base64 encoding when CROSS_DOMAIN = 1

### DIFF
--- a/html2canvasproxy.php
+++ b/html2canvasproxy.php
@@ -634,8 +634,8 @@ if(is_array($response) && isset($response['mime']) && strlen($response['mime']) 
                 $tmp = $response = null;
 
                 if (
-                    strpos($response['mime'], 'image/svg') !== 0 &&
-                    strpos($response['mime'], 'image/') === 0
+                    strpos($mime, 'image/svg') !== 0 &&
+                    strpos($mime, 'image/') === 0
                 ) {
                     echo $param_callback, '("data:', $mime, ';base64,',
                         base64_encode(


### PR DESCRIPTION
$response['mime'] is null when the conditional is run because a couple lines (line 634) above it $tmp = $response = null; sets $response to null.
